### PR TITLE
【修复】修正一个类命名问题

### DIFF
--- a/src/Exceptions/HandleException.php
+++ b/src/Exceptions/HandleException.php
@@ -10,7 +10,7 @@ use Exception;
 * @license  https://opensource.org/licenses/MIT MIT
 * @link     https://github.com/czewail/think-api
 */
-class handleException extends Handle
+class HandleException extends Handle
 {
     /**
     * render


### PR DESCRIPTION
HandleException类名首字母小写与文件名不一致，导致在某些环境下无法获取